### PR TITLE
Update plugin date release

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -3,7 +3,7 @@
 base   pagetemplater
 author i-net software
 email  tools@inetsoftware.de
-date   2009-03-16
+date   2013-11-20
 name   Page Templater Plugin
 desc   Select Template Pages for your Content.
 url    https://github.com/i-net-software/dokuwiki-plugin-pagetemplater


### PR DESCRIPTION
Because the old date is still listed in this file, the Extension Manager keeps showing "New version 2013-11-20 is available." even if the latest update is already installed.
